### PR TITLE
Feature/add parameter observer

### DIFF
--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -4,7 +4,7 @@ from src.synthesizers.super_simple_synth import SuperSimpleHost
 from pyvst import SimpleHost
 
 # Import observer and actor network
-from src.observers.spectrogram_observer import build_spectrogram_observer
+from src.observers.parameter_observer import build_parameter_observer
 from src.agents.actor_critic_agent import ActorCriticAgent
 
 from src.utils.replay_buffer import ReplayBuffer
@@ -18,8 +18,8 @@ SAMPLING_RATE = 44100.0
 NOTE_LENGTH = 0.5
 
 # Create synthesizer object
-# host = SuperSimpleHost(sample_rate=SAMPLING_RATE)
-host = SimpleHost("/mnt/c/github/synth-match/amsynth_vst.so", sample_rate=SAMPLING_RATE)
+host = SuperSimpleHost(sample_rate=SAMPLING_RATE)
+# host = SimpleHost("/mnt/c/github/synth-match/amsynth_vst.so", sample_rate=SAMPLING_RATE)
 
 # Create environment object and pass synthesizer object
 env = Environment(synth_host=host, note_length=NOTE_LENGTH, control_mode="incremental", render_mode=True, sampling_freq=SAMPLING_RATE)
@@ -31,7 +31,7 @@ input_shape = env.get_input_shape()
 output_shape = env.get_output_shape()
 
 # Create Observer network and Actor Critic agent network
-observer_network = build_spectrogram_observer(
+observer_network = build_parameter_observer(
     input_shape=input_shape  # (int(SAMPLING_RATE*NOTE_LENGTH), 1)
 )
 model = ActorCriticAgent(

--- a/src/observers/parameter_observer.py
+++ b/src/observers/parameter_observer.py
@@ -1,0 +1,20 @@
+"""
+DEBUG / DEVELOPMENT CODE
+This observer directly passes the synthesizer parameters error to the agent network.
+The purpose of this observer is to debug the agent logic in a simplified setup (instead of end-to-end training).
+"""
+
+from tensorflow.keras.layers import Input
+from tensorflow.keras.models import Model
+
+
+def build_parameter_observer(input_shape=(2,)):
+    inputs = Input(shape=input_shape)
+    # Directly use the inputs as outputs
+    model = Model(inputs=inputs, outputs=inputs)
+    return model
+
+
+if __name__ == "__main__":
+    observer_network = build_parameter_observer()
+    observer_network.summary()

--- a/src/utils/audio_processor.py
+++ b/src/utils/audio_processor.py
@@ -14,7 +14,7 @@ class AudioProcessor:
     def update_sample(self, audio_sample):
         self.audio_sample = audio_sample
         self.convert_to_mono()
-        self.crop_sample(length=2.0)
+        self.crop_sample(length=1.0)
         self.calculate_spectrogram()
 
     def convert_to_mono(self):


### PR DESCRIPTION
DEBUG / DEVELOPMENT CODE
This observer directly passes the synthesizer parameters error to the agent network.
The purpose of this observer is to debug the agent logic in a simplified setup (instead of end-to-end training).